### PR TITLE
NATS Gatling Connector

### DIFF
--- a/src/sphinx/extensions/index.rst
+++ b/src/sphinx/extensions/index.rst
@@ -24,6 +24,7 @@ Third Parties
 * `Kafka plugin <https://github.com/mnogu/gatling-kafka>`_
 * `RabbitMQ plugin <https://github.com/maiha/gatling-amqp>`_
 * `AMQP plugin <https://github.com/maiha/gatling-amqp>`_
+* `NATS Gatling Connector <https://github.com/Logimethods/nats-connector-gatling>`_
 
 .. warning::
   Those projects are third parties and are not maintained by the Gatling core committers.


### PR DESCRIPTION
You might add the following plugin into your list of Extensions (http://gatling.io/#/resources/about): https://github.com/Logimethods/nats-connector-gatling (NATS Gatling Connector by Laurent Magnin / Logimethods)
